### PR TITLE
Make basic compile work with ant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ nb-configuration.xml
 # Project specific #
 BuildTimeStrings.properties
 
+# Resulting zip file.
+dist.zip
+
 # Class Files #
 *.class
 
@@ -23,4 +26,3 @@ BuildTimeStrings.properties
 *.jar
 *.war
 *.ear
-

--- a/build.xml
+++ b/build.xml
@@ -1,113 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- You may freely edit this file. See commented blocks below for -->
-<!-- some examples of how to customize the build. -->
-<!-- (If you delete it and reopen the project it will be recreated.) -->
-<!-- By default, only the Clean and Build commands use this build script. -->
-<!-- Commands such as Run, Debug, and Test only use this build script if -->
-<!-- the Compile on Save feature is turned off for the project. -->
-<!-- You can turn off the Compile on Save (or Deploy on Save) setting -->
-<!-- in the project's Project Properties dialog box.-->
-<project name="rope1401" default="default" basedir=".">
-    <description>Builds, tests, and runs the project rope1401.</description>
-    <import file="nbproject/build-impl.xml"/>
-    <!--
-
-    There exist several targets which are by default empty and which can be 
-    used for execution of your tasks. These targets are usually executed 
-    before and after some main targets. They are: 
-
-      -pre-init:                 called before initialization of project properties
-      -post-init:                called after initialization of project properties
-      -pre-compile:              called before javac compilation
-      -post-compile:             called after javac compilation
-      -pre-compile-single:       called before javac compilation of single file
-      -post-compile-single:      called after javac compilation of single file
-      -pre-compile-test:         called before javac compilation of JUnit tests
-      -post-compile-test:        called after javac compilation of JUnit tests
-      -pre-compile-test-single:  called before javac compilation of single JUnit test
-      -post-compile-test-single: called after javac compilation of single JUunit test
-      -pre-jar:                  called before JAR building
-      -post-jar:                 called after JAR building
-      -post-clean:               called after cleaning build products
-
-    (Targets beginning with '-' are not intended to be called on their own.)
-
-    Example of inserting an obfuscator after compilation could look like this:
-
-        <target name="-post-compile">
-            <obfuscate>
-                <fileset dir="${build.classes.dir}"/>
-            </obfuscate>
-        </target>
-
-    For list of available properties check the imported 
-    nbproject/build-impl.xml file. 
-
-
-    Another way to customize the build is by overriding existing main targets.
-    The targets of interest are: 
-
-      -init-macrodef-javac:     defines macro for javac compilation
-      -init-macrodef-junit:     defines macro for junit execution
-      -init-macrodef-debug:     defines macro for class debugging
-      -init-macrodef-java:      defines macro for class execution
-      -do-jar:                  JAR building
-      run:                      execution of project 
-      -javadoc-build:           Javadoc generation
-      test-report:              JUnit report generation
-
-    An example of overriding the target for project execution could look like this:
-
-        <target name="run" depends="rope1401-impl.jar">
-            <exec dir="bin" executable="launcher.exe">
-                <arg file="${dist.jar}"/>
-            </exec>
-        </target>
-
-    Notice that the overridden target depends on the jar target and not only on 
-    the compile target as the regular run target does. Again, for a list of available 
-    properties which you can use, check the target you are overriding in the
-    nbproject/build-impl.xml file. 
-
-    -->
 <!--
-	Last changes by Luca Severini (lucaseverini@mac.com) on April 24 2014.
+Last changes by Luca Severini (lucaseverini@mac.com) on April 24 2014.
+                Henner Zeller (h.zeller@acm.org) Sept 2016
 -->
 
-	<!-- <property name="app.icon.icns" value="rope1401.icns"/> -->
-	
-<!--
-	Execute the script that creates the property file containing some properties used as strings
--->		
-	<target name="-pre-compile">
-		<exec dir="." executable="/bin/sh" os="Mac OS X">
-			<arg line="create_properties.sh"/>
-		</exec>
-		
-		<!-- For windows it's necessary to have MinGW or compatible environment installed -->
-		<exec dir="." executable="C:\Programmi\Git\bin\sh.exe" os="Windows XP 5.1">
-			<arg line="--login -i create_properties.sh"/>
-		</exec>
-	</target>
-	
-<!--
-	Copy the tools folder with all its content except invisible files
--->		
-	<target name="-post-jar"> 
-        <copy todir="${dist.dir}/tools" includeEmptyDirs="true" verbose="true" overwrite="true" preservelastmodified="true"> 
-			<fileset dir="tools/" followsymlinks="true" excludes=".*">
-				<include name="*/*"/>
-			</fileset>
-		</copy>
-		
-<!--
-	Make the mac tools executable
--->		
-		<chmod perm="ug+x">
-			<fileset dir="${dist.dir}/tools">
-				<include name="*/*"/>
-			</fileset>
-		</chmod>
-    </target>
-	
+<project name="rope1401" default="default" basedir=".">
+  <description>Builds, tests, and runs the project rope1401.</description>
+  <property name="dist.dir" value="dist"/>
+  <property name="build.dir" value="build"/>
+
+  <target name="default" depends="compile"/>
+  <target name="dist" depends="jar,-post-jar"/>
+
+  <target name="dist.zip" depends="dist">
+    <zip destfile="dist.zip" basedir="${dist.dir}"/>
+  </target>
+
+  <target name="compile" depends="-pre-compile">
+    <mkdir dir="${build.dir}"/>
+    <javac srcdir="src" destdir="build"/>
+  </target>
+
+  <target name="jar" depends="compile">
+    <mkdir dir="${dist.dir}"/>
+    <jar destfile="${dist.dir}/rope1401.jar">
+      <fileset dir="src/" includes="rope1401/Images/**"/>
+      <fileset dir="src/" includes="rope1401/Resources/**"/>
+      <fileset dir="${build.dir}/"/>
+      <manifest>
+	<attribute name="Main-Class" value="rope1401.ROPE"/>
+      </manifest>
+    </jar>
+  </target>
+
+  <!--
+      Execute the script that creates the property file containing some
+      properties used as strings
+  -->
+  <target name="-pre-compile">
+    <exec dir="." executable="/bin/bash" os="Linux">
+      <arg line="create_properties.sh"/>
+    </exec>
+    <exec dir="." executable="/bin/sh" os="Mac OS X">
+      <arg line="create_properties.sh"/>
+    </exec>
+    <exec dir="." executable="C:\Programmi\Git\bin\sh.exe" os="Windows XP 5.1">
+      <arg line="--login -i create_properties.sh"/>
+    </exec>
+  </target>
+
+  <!--
+      Copy the tools folder with all its content except invisible files
+  -->
+  <target name="-post-jar">
+    <copy todir="${dist.dir}/tools" includeEmptyDirs="true"
+	  verbose="true" overwrite="true" preservelastmodified="true">
+      <!-- need to exclude mac tool right now as it is a dead links -->
+      <fileset dir="tools/" followsymlinks="true" excludes="mac/*">
+	<include name="*/*"/>
+      </fileset>
+    </copy>
+
+    <!--
+	Make the mac/linux tools executable
+    -->
+    <chmod perm="ug+x">
+      <fileset dir="${dist.dir}/tools">
+	<include name="*/*"/>
+      </fileset>
+    </chmod>
+  </target>
 </project>

--- a/create_properties.sh
+++ b/create_properties.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 #
-# This bash script creates the property file containing the properties used 
+# This bash script creates the property file containing the properties used
 # in the java program ROPE.
-# On Windows, it requires MinGW (http://www.mingw.org) or compatible 
+# On Windows, it requires MinGW (http://www.mingw.org) or compatible
 # unix shell environment.
 #
 # By Luca Severini (lucaseverini@mac.com)
@@ -12,9 +12,10 @@
 
 PROPERTIES_FILE_PATH=./src/rope1401/Resources/BuildTimeStrings.properties
 
-if [[ "$(uname)" = "Darwin" ]]
-then
+if [[ "$(uname)" = "Darwin" ]] ; then
 	PLATFORM="Mac OS X"
+elif [[ "$(uname)" = "Linux" ]] ; then
+        PLATFORM="Linux"
 else
 	PLATFORM="Windows"
 fi

--- a/src/rope1401/ROPE.java
+++ b/src/rope1401/ROPE.java
@@ -9,9 +9,11 @@
 
 package rope1401;
 
-import com.apple.eawt.Application;
 import javax.swing.ImageIcon;
 import javax.swing.UIManager;
+
+// Only import these when compiling on Mac
+// import com.apple.eawt.Application;
 // import com.apple.eawt.QuitStrategy;
 
 public class ROPE /* extends com.apple.eawt.Application */
@@ -29,8 +31,8 @@ public class ROPE /* extends com.apple.eawt.Application */
 		
 		if(RopeHelper.isMac)
 		{
-			// Use reflection here...
-			Application.getApplication().setDockIconImage(new ImageIcon(getClass().getResource("Images/appIcon330.gif")).getImage());
+			// TODO: Use reflection here so that it works on all platforms...
+			//Application.getApplication().setDockIconImage(new ImageIcon(getClass().getResource("Images/appIcon330.gif")).getImage());
 			
 			System.setProperty("apple.awt.graphics.EnableQ2DX", "true");
 			System.setProperty("apple.laf.useScreenMenuBar", "true");


### PR DESCRIPTION
o Make the build.xml functional to compile stuff. Looks like it was 
 generated a long time ago with netbeans, but doesn't work anymore. Remove unnecessary boilerplate.
o Provide targets 'compile', 'dist', 'dist.zip'
o Fix build script to use /bin/bash instead of /bin/sh as it uses
  bash specific feature [[ ]]
o Add a uname build platform for Linux.
