### PR TITLE
Fix a couple of syntax errors in assembly code.

### DIFF
--- a/examples/BiggerPi.s
+++ b/examples/BiggerPi.s
@@ -33,7 +33,7 @@
      * OVERLAY PRINT AREA
      START     MCW  @000000@,ITCNT  * ZERO ITERATION CNTR
                MCW  @000001@,IX2P1  * INIT INTER DIVISOR
-               MCW  @+@,ACCUM&5049 * ZERO ACCUMULATOR
+               MCW  @+@,ACCUM&5049  * ZERO ACCUMULATOR
                MCW  @0@,ACCUM&5048
                MCW  ACCUM&5048,ACCUM&5047 
                MCW  @0@,BASET&5048
@@ -121,7 +121,7 @@
                SW   203,214    * SET WORD MARKS FOR B FIELD
                SW   225,236
                SW   247,265
-               A    @00050@,269 * ADD 50 TO EXPONENT
+               A    @00050@,269  * ADD 50 TO EXPONENT
                MCW  ACCUM&X1,212  MOVE 1ST FIELD
                SBR  X1,10&X1     * STEP X1
                MCW  ACCUM&X1,223  MOVE 2ND FIELD

--- a/examples/powers2.s
+++ b/examples/powers2.s
@@ -12,7 +12,7 @@
                CS          * 200s  201 IS HIGH ORDER OF PRINT AREA - TO 332
                SW   500,350  * SET WORD MARKS FOR WORK AREAS
                SW   200    * SET WORD MARK FOR PRINT AREA COMPARE 
-               MCW  @1@,632 * SET INITIAL 2^0
+               MCW  @1@,632  * SET INITIAL 2^0
                MCW  @56789@,204  * set test pattern for bug check ;-))
                W           *write the TEST PATTERN  area to the printer
      *                       SEE IF LOCATION 202 IS KLOBBERED :-))


### PR DESCRIPTION
Avoid autocoder errors such as
  (2) Name must not be followed by \* or character literal
  (2) Missing punctuation here
that seem to happen if there is not enough whitespace after an
instruction.
